### PR TITLE
1.0.3 win_dhcp_server - Fix typo error in template

### DIFF
--- a/templates/global/command-win_dhcp_server_conflict_detection_attempts.ps1.epp
+++ b/templates/global/command-win_dhcp_server_conflict_detection_attempts.ps1.epp
@@ -2,7 +2,7 @@
 Integer[0, 5] $conflict_detection_attempts
 | -%>
 import-module dhcpserver;
-[Int32]$ConflictDetectionAttempts = $<%= $conflict_detection_attempts %>;
+[Int32]$ConflictDetectionAttempts = <%= $conflict_detection_attempts %>;
 
 $existingSetting = (Get-DhcpServerSetting).ConflictDetectionAttempts;
 


### PR DESCRIPTION
A `$` symbol inserted before the value to be set was leading making the value to always default to 0 as $[1-5] is not a valid integer and hence won't set any value.