### PR TITLE
win_dhcp_server - Fix typo error in template

### DIFF
--- a/templates/global/unless-win_dhcp_server_conflict_detection_attempts.ps1.epp
+++ b/templates/global/unless-win_dhcp_server_conflict_detection_attempts.ps1.epp
@@ -2,7 +2,7 @@
 Integer[0, 5] $conflict_detection_attempts
 | -%>
 import-module dhcpserver;
-[Int32]$ConflictDetectionAttempts = $<%= $conflict_detection_attempts %>;
+[Int32]$ConflictDetectionAttempts = <%= $conflict_detection_attempts %>;
 
 $existingSetting = (Get-DhcpServerSetting).ConflictDetectionAttempts;
 


### PR DESCRIPTION
A `$` symbol inserted before the value to be tested was making the value to always default to 0 as $[1-5] is not a valid integer and hence will default to 0 and will never run the exec command.