### PR TITLE
Tag to point latest master: Bug Fix - unless_conflict_detection_attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
-1.0.4 - correct typo of incorrect '$' before int to determine number of IP conflict detection attempts, uncovered by @amitp18
+1.0.5 - correct typo of incorrect '$' exec unless before int to determine number of IP conflict detection attempts, uncovered by @amitp18
+1.0.4 - correct typo of incorrect '$' in exec cmd before int to determine number of IP conflict detection attempts, uncovered by @amitp18
 1.0.0 - initial release

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "karmafeast-win_dhcp_server",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "karmafeast",
   "summary": "management of windows DHCP services",
   "license": "Apache-2.0",


### PR DESCRIPTION
@karmafeast Module version 1.0.4 doesn't point to the latest master and hence the bug fix for the unless typo is not working.
Please accept this MR and create a new tag 1.0.5.