### PR TITLE
1.0.5 - correction of typo in 'unless' conflict detection template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+1.0.5 - correct typo of incorrect '$' before int to determine number of IP conflict detection attempts (unless check)
 1.0.4 - correct typo of incorrect '$' before int to determine number of IP conflict detection attempts, uncovered by @amitp18
 1.0.0 - initial release

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "karmafeast-win_dhcp_server",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "karmafeast",
   "summary": "management of windows DHCP services",
   "license": "Apache-2.0",


### PR DESCRIPTION
1.0.4 version doesn't include the typo fixes on unless check on the IP conflict detection. there was an incorrect '$' before an int value we need in rendered PS. This merge will generate a new tag that includes the required fixes for the IP conflict detection to work as expected.